### PR TITLE
Support bzip2 compressed info files

### DIFF
--- a/inform.el
+++ b/inform.el
@@ -239,6 +239,7 @@ directory or in `package-user-dir' and is not included in the
 	 (or (assoc-string (concat ifi ".info") ifiles)
 	     ;; info files might be archived on disc!
 	     (assoc-string (concat ifi ".info.gz") ifiles)
+	     (assoc-string (concat ifi ".info.bz2") ifiles)
 	     (when pdir (string-match pdir ifile)))
 	 (not (assoc-string ifi ndocu)))))
 


### PR DESCRIPTION
This is a very trivial PR to add support for bzip2 compressed info files.

I see that there is already support for gzip compressed info files (aka .gz) in the function `inform-check-docu-p`. On my system (Gentoo) all info files are compressed with bzip2 (aka .bz2), so Inform fails to work... Adding support to bzip2 compressed info files, as expected, gets the harmony back!